### PR TITLE
`Sprockets::Asset` no longer responds to `#body`

### DIFF
--- a/lib/rspec/respect_selector_limit/respect_selector_limit_matcher.rb
+++ b/lib/rspec/respect_selector_limit/respect_selector_limit_matcher.rb
@@ -7,7 +7,7 @@ RSpec::Matchers.define :respect_selector_limit do
   end
 
   def valid_asset?(asset)
-    css = Rails.application.assets[asset].body
+    css = Rails.application.assets[asset].to_s
 
     parser = CssParser::Parser.new
     parser.add_block!(css)


### PR DESCRIPTION
Change to using `#to_s`

Fixes the following error:

```
Failure/Error: expect('application.css').to respect_selector_limit
     NoMethodError:
       undefined method `body' for #<Sprockets::Asset:0x007f8769463c08>
```
